### PR TITLE
Add refine_prior argument

### DIFF
--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -52,7 +52,10 @@ setGeneric("compute_accession_coverage",
 
 
 setGeneric("infer_parsimonious_accessions",
-           function(object, unique_only=FALSE, prior=character(0)) 
+           function(object, 
+                    unique_only=FALSE, 
+                    prior=character(0),
+                    refine_prior=FALSE) 
                standardGeneric("infer_parsimonious_accessions"))
 
 

--- a/R/MSnID-methods.R
+++ b/R/MSnID-methods.R
@@ -578,7 +578,10 @@ setAs("MSnID", "MSnSet",
 utils::globalVariables(c("accession", "N", "pepSeq", "num"))
 
 setMethod("infer_parsimonious_accessions", "MSnID",
-          definition=function(object, unique_only=FALSE, prior=character(0))
+          definition=function(object, 
+                              unique_only=FALSE, 
+                              prior=character(0),
+                              refine_prior=FALSE)
           {
               infer_acc <- function(x){
                   res <- list()
@@ -613,6 +616,12 @@ setMethod("infer_parsimonious_accessions", "MSnID",
                   # this removes other proteins mapped to 
                   # peptides from prior justified proteins
                   res_prior <- x_prior[accession %in% prior]
+                  
+                  # Apply razor rule to prior as well
+                  if (refine_prior) {
+                      res_prior <- infer_acc(res_prior)
+                  }
+                  
                   # key step. the slowest
                   res_current <- infer_acc(x_current)
                   #

--- a/inst/unitTests/test_infer_parsimonious_accessions.R
+++ b/inst/unitTests/test_infer_parsimonious_accessions.R
@@ -1,4 +1,5 @@
 library("MSnID")
+library(data.table)
 data(c_elegans)
 
 
@@ -22,7 +23,7 @@ test_infer_parsimonious_accessions_old <- function(){
 # outside of the test functions.
 
 
-# explicitely adding parameters that will be used for data filtering
+# explicitly adding parameters that will be used for data filtering
 msnidObj$msmsScore <- -log10(msnidObj$`MS-GF:SpecEValue`)
 msnidObj$absParentMassErrorPPM <- abs(mass_measurement_error(msnidObj))
 # quick-and-dirty filter. The filter is too strong for the sake of saving time
@@ -35,13 +36,47 @@ msnidObj.r <- infer_parsimonious_accessions(msnidObj, unique_only=FALSE)
 # checking unique peptides only
 msnidObj.u <- infer_parsimonious_accessions(msnidObj, unique_only=TRUE)
 
+# checking with prior
+set.seed(9001)
+prior <- sample(accessions(msnidObj), size = 100)
+msnidObj.p <- infer_parsimonious_accessions(msnidObj, unique_only=FALSE, prior = prior)
+
+# checking with refined prior (no duplicate peptides)
+msnidObj.pr <- infer_parsimonious_accessions(msnidObj, unique_only=FALSE, prior=prior, refine_prior=TRUE)
+
+
+# Check protein counts
 test_infer_parsimonious_accessions_number.r <- function(){
    checkEqualsNumeric(length(proteins(msnidObj.r)), 551)
 }
 test_infer_parsimonious_accessions_number.u <- function(){
     checkEqualsNumeric(length(proteins(msnidObj.u)), 427)
 }
+test_infer_parsimonious_accessions_number.p <- function(){
+    checkEqualsNumeric(length(proteins(msnidObj.p)), 564)
+}
+test_infer_parsimonious_accessions_number.pr <- function(){
+    checkEqualsNumeric(length(proteins(msnidObj.pr)), 558)
+}
 
+# Check uniqueness of peptides ----
+# default settings
+dt.r <- unique(msnidObj.r@psms[, list(accession, pepSeq)])
+test_infer_parsimonious_accessions_uniqueness <- function() {
+    checkTrue(all(table(dt.r$pepSeq) == 1))
+}
+# unique_only = TRUE
+dt.u <- unique(msnidObj.u@psms[, list(accession, pepSeq)])
+test_infer_parsimonious_accessions_uniqueness <- function() {
+    checkTrue(all(table(dt.u$pepSeq) == 1))
+}
+# refined prior
+dt.pr <- unique(msnidObj.pr@psms[, list(accession, pepSeq)])
+test_infer_parsimonious_accessions_uniqueness <- function() {
+    checkTrue(all(table(dt.pr$pepSeq) == 1))
+}
+
+# Check exact contents
 test_infer_parsimonious_accessions_hash.r <- function(){
     checkIdentical(digest(psms(msnidObj.r)$accession),
                    'e8ff9bbf36929ce49850733b3640edc8')
@@ -49,6 +84,14 @@ test_infer_parsimonious_accessions_hash.r <- function(){
 test_infer_parsimonious_accessions_hash.u <- function(){
     checkIdentical(digest(psms(msnidObj.u)$accession),
                    '2a375d3ec85d022aeba5d210bca55a53')
+}
+test_infer_parsimonious_accessions_hash.p <- function(){
+    checkIdentical(digest(psms(msnidObj.p)$accession),
+                   'ace5f0f29bb960dfeeafa469f16d65c5')
+}
+test_infer_parsimonious_accessions_hash.pr <- function(){
+    checkIdentical(digest(psms(msnidObj.pr)$accession),
+                   '47a8a9075d22e5b3d9dc4102ba4bf908')
 }
 
 # Future challenges is to come up with tests that check inference that is

--- a/man/infer_parsimonious_accessions.Rd
+++ b/man/infer_parsimonious_accessions.Rd
@@ -5,17 +5,20 @@
 \title{Eliminates Redundancy in Peptide-to-Protein Mapping}
 
 \description{
-    Infer parsimonious set of accessions (e.g. proteins) 
-    that explains all the peptide sequences. The algorithm is a 
-    simple loop that looks for the accession explaining most peptides,
+    Infer the parsimonious set of accessions (e.g. proteins) 
+    that explains all of the peptide sequences. The algorithm is a 
+    simple loop that looks for the accession explaining the most peptides,
     records the peptide-to-accession mapping for this accession,
-    removes those peptides, and then looks for next best accession. The
-    loop continues until no peptides left. The method does not accept
-    any arguments at this point (except the MSnID object itself).
+    removes those peptides, and then looks for the next best accession. The
+    loop continues until no peptides are left. This is known as the greedy set 
+    cover algorithm.
 }
 
 \usage{
-    infer_parsimonious_accessions(object, unique_only=FALSE, prior=character(0))
+    infer_parsimonious_accessions(object, 
+                                  unique_only=FALSE, 
+                                  prior=character(0),
+                                  refine_prior=FALSE)
 }
 
 %- maybe also 'usage' for other objects documented here.
@@ -25,24 +28,31 @@
     }
     \item{unique_only}{
         If TRUE, peptides mapping to multiple accessions are dropped and
-        only unique are retained. If FALSE, then shared peptides assigned
+        only unique are retained. If \code{FALSE}, then shared peptides assigned
         according to Occam's razor rule. That is a shared peptide is 
         assigned to a protein with larger number of unique peptides.
         If the number of unique peptides is the same, then to the first 
-        accession. Default is FALSE.
+        accession. Default is \code{FALSE}.
     }
     \item{prior}{(character)
         character vector with prior justified proteins/accessions.
         If \code{unique_only == TRUE}, then \code{prior} argument is
-        ignored. Essentially evidence by presense of unique peptide supercedes
-        any prior. Default is \code{character(0)}, that is none.
+        ignored. Essentially, evidence by presence of unique peptide supercedes
+        any prior. Default is \code{character(0)}: that is, no prior.
+    }
+    \item{refine_prior}{(logical)
+        if \code{FALSE} (default), peptides are allowed to match multiple
+        proteins in the prior. That is, the greedy set cover algorithm is only
+        applied to the set of proteins not in the prior. If \code{TRUE}, the
+        algorithm is applied to the prior and non-prior sets separately before
+        combining.
     }
 }
 
 \details{
-    Although the algorithm is rather simple it is THE algorithm used for
-    inferring maximal matching in bipartate graphs and is used in the 
-    IDPicker software.
+    Although the algorithm is rather simple, it is \emph{THE} algorithm used for
+    inferring maximal matching in bipartite graphs and is used in the 
+    IDPicker software (see References).
 }
 
 \value{
@@ -51,11 +61,17 @@
 }
 
 \author{
-    Vladislav A Petyuk \email{vladislav.petyuk@pnnl.gov}
+    Vladislav A Petyuk \email{vladislav.petyuk@pnnl.gov},
+    Colin Brislawn,
+    Tyler Sagendorf
 }
 
 \seealso{
     \code{\link{MSnID}}
+}
+
+\references{
+Zhang, B., Chambers, M. C., & Tabb, D. L. (2007). Proteomic parsimony through bipartite graph analysis improves accuracy and transparency. Journal of Proteome Research, 6(9), 3549-3557. PubMed. \url{https://doi.org/10.1021/pr070230d}
 }
 
 


### PR DESCRIPTION
Add the `refine_prior` argument to `infer_parsimonious_accessions` and set to `FALSE` by default. This applies the greedy set cover algorithm to both the non-prior and prior sets to ensure that each peptide will only match a single protein. Updated associated documentation and unit tests.