### PR TITLE
Update parse_FASTA_names

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -8,8 +8,7 @@ import("iterators")
 import("data.table")
 importFrom("dplyr", "group_by", "summarise", "select", "%>%", "inner_join",
            "left_join", "rename", "mutate", "filter", "group_by_at", "distinct", 
-           "top_n", "pull", "tally", "ungroup", "arrange", "n", "across", 
-           "everything")
+           "top_n", "pull", "tally", "ungroup", "arrange", "n")
 importFrom("rlang", "!!", "sym")
 importFrom("tibble", "rownames_to_column")
 importFrom("stringi", "stri_reverse")

--- a/R/parse_FASTA_names.R
+++ b/R/parse_FASTA_names.R
@@ -63,9 +63,7 @@ parse_FASTA_names <- function(path_to_FASTA,
   out[, num_cols] <- out[, lapply(.SD, as.numeric), .SDcols = num_cols]
   
   # Remove columns with all missing values
-  out <- out[, which(unlist(
-    lapply(out, function(x) { !all(is.na(x)) })
-  )), with = FALSE]
+  out <- out[, colSums(!is.na(out)) != 0, with = FALSE]
   
   setDF(out)
   

--- a/R/parse_FASTA_names.R
+++ b/R/parse_FASTA_names.R
@@ -9,86 +9,71 @@ parse_FASTA_names <- function(path_to_FASTA,
   # Get FASTA headers
   fasta_names <- names(readAAStringSet(path_to_FASTA))
   
+  # Remove contaminants
+  fasta_names <- fasta_names[!grepl("^contaminant", fasta_names, 
+                                    ignore.case = TRUE)]
+  
   if (database == "uniprot") {
-    # Pattern for first 6 columns
-    pttrn <- "(.*)\\|(.*)\\|([^ ]+) (.*) OS=(.*) OX=(\\d+).*"
+    pttrn <- "(?<header>(?<feature>^(?<database>[^\\|]+)\\|(?<unique_id>(?<uniprot_acc>[^\\|-]+)-?(?<isoform>\\d*))\\|(?<entry_name>\\w+))\\s+(?<description>.*)\\s+OS=(?<organism>.*)\\s+OX=(?<organism_id>\\d+).*$)"
     
-    out <- data.frame(
-      feature = sub(" .*", "", fasta_names),
-      database = sub(pttrn, "\\1", fasta_names),
-      uniprot_acc = sub(pttrn, "\\2", fasta_names),
-      entry_name = sub(pttrn, "\\3", fasta_names),
-      description = sub(pttrn, "\\4", fasta_names),
-      organism = sub(pttrn, "\\5", fasta_names),
-      organism_id = sub(pttrn, "\\6", fasta_names),
-      # These last 3 may not be present, so we use separate regex
-      gene = sub(".* GN=([^ ]+).*", "\\1", fasta_names),
-      protein_existence = sub(".* PE=(\\d+).*", "\\1", fasta_names),
-      sequence_version = sub(".* SV=(\\d+)$", "\\1", fasta_names)
-    ) %>%
-      mutate(
-        isoform = str_extract(uniprot_acc, "(?<=-)\\d+"),
-        uniprot_acc = sub("-.*", "", uniprot_acc),
-        # By default, a failed match uses the original string.
-        # Replace with NA
-        across(
-          .cols = everything(),
-          .fns = ~ ifelse(.x == fasta_names, NA, .x)
-        )
-      ) %>%
-      # Remove entries that do not follow the format (no database entry)
-      dplyr::filter(!is.na(database)) %>%
-      # Convert these columns from character to numeric
-      mutate(across(
-        .cols = c(
-          isoform, protein_existence,
-          sequence_version, organism_id
-        ),
-        .fns = as.numeric
-      )) %>%
-      # Reorder columns
-      dplyr::select(feature, database, uniprot_acc, isoform, everything())
+    m <- regexec(pattern = pttrn, text = fasta_names, perl = TRUE)
+    out <- do.call(rbind, lapply(regmatches(fasta_names, m), `[`, -1L))
+    out <- as.data.table(out)
+    
+    # Additional columns 
+    # (Including positive lookbehind in pttrn removes isoform rows...)
+    out[, `:=`(
+      gene = sub(".*(?<=GN=)(\\S+).*", "\\1", header, perl = TRUE),
+      protein_existence = sub(".*(?<=PE=)(\\d+).*", "\\1", header, perl = TRUE),
+      sequence_version = sub(".*(?<=SV=)(\\d+)", "\\1", header, perl = TRUE),
+      header = NULL
+    )]
+    
+    # Convert these columns to numeric
+    num_cols <- c("isoform", "protein_existence", 
+                  "sequence_version", "organism_id")
     
   } else if (database == "gencode") {
+    # Expect 8 sections separated by pipe
     pttrn <- paste(rep("([^\\|]+)", times = 8), collapse = "\\|")
-    pttrn <- paste0(pttrn, "(.*$)")
+    pttrn <- paste0(pttrn, ".*") # account for any additional information
     
-    out <- data.table(value = fasta_names)
-    out[, `:=`(
-      protein_id = sub(pttrn, "\\1", value),
-      transcript_id = sub(pttrn, "\\2", value),
-      gene_id = sub(pttrn, "\\3", value),
-      havana_gene = sub(pttrn, "\\4", value),
-      havana_transcript = sub(pttrn, "\\5", value),
-      transcript = sub(pttrn, "\\6", value),
-      gene = sub(pttrn, "\\7", value),
-      prot_length = as.numeric(sub(pttrn, "\\8", value)),
-      extra_info = sub(pttrn, "\\9", value),
-      value = NULL
-    )]
-    # Clean up columns
-    out[out == "" | out == "-"] <- NA
-    # Remove columns with all missing values
-    out <- out[, which(unlist(
-      lapply(out, function(x) !all(is.na(x)))
-    )), with = FALSE]
-    out <- as.data.frame(out)
+    # Much faster than calling sub() separately for each column
+    m <- regexec(pattern = pttrn, text = fasta_names)
+    out <- do.call(rbind, lapply(regmatches(fasta_names, m), `[`, -1L))
+    out <- as.data.table(out)
+    colnames(out) <- c("protein_id", "transcript_id", "gene_id", "havana_gene", 
+                       "havana_transcript", "transcript", "gene", 
+                       "protein_length")
+    
+    # Convert these columns to numeric
+    num_cols <- c("protein_length")
   }
+  
+  # Replace failed matches with NA
+  for (j in seq_along(out)) {
+    set(out, i = which(out[[j]] %in% c(fasta_names, "-", "")), j = j, 
+        value = NA)
+  }
+  
+  # Remove rows with all missing values
+  out <- out[rowSums(!is.na(out)) != 0, ]
+  
+  # Convert certain columns to numeric
+  out[, num_cols] <- out[, lapply(.SD, as.numeric), .SDcols = num_cols]
+  
+  # Remove columns with all missing values
+  out <- out[, which(unlist(
+    lapply(out, function(x) { !all(is.na(x)) })
+  )), with = FALSE]
+  
+  setDF(out)
   
   return(out)
 }
 
 
 utils::globalVariables(
-  c(
-    "uniprot_acc",
-    "database",
-    "isoform",
-    "feature",
-    "protein_existence",
-    "sequence_version",
-    "organism_id",
-    "value"
-  )
+  c("header")
 )
 

--- a/inst/unitTests/test_parse_FASTA_names.R
+++ b/inst/unitTests/test_parse_FASTA_names.R
@@ -11,6 +11,7 @@ test_parse_FASTA_names <- function() {
                 "sp|Q920B6-4|KCNK2_RAT", "sp|Q9WUW9|S1C2A_RAT", 
                 "sp|Q6PCU8|NDUV3_RAT", "sp|O35509|RB11B_RAT"),
     database = "sp", 
+    unique_id = c("P61943", "P56576", "Q920B6-4", "Q9WUW9", "Q6PCU8", "O35509"),
     uniprot_acc = c("P61943", "P56576", "Q920B6", "Q9WUW9", "Q6PCU8", "O35509"),
     isoform = c(rep(NA, 2), 4, rep(NA, 3)),
     entry_name = c("SIA10_RAT", "UH11_RAT", "KCNK2_RAT", "S1C2A_RAT", 


### PR DESCRIPTION
Add `unique_id` column to UniProt results (combination of accession and isoform), remove contaminants before parsing, speed improvements from switching to `regexec` + `regmatches` and `data.table` syntax.